### PR TITLE
docs: remove Product Hunt banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
   </p>
 
   <p>
-    <a href="https://www.producthunt.com/products/linearmemory-ai-memory-explorer?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-linearmemory-ai-memory-explorer" target="_blank" rel="noopener noreferrer"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=linearmemory-ai-memory-explorer&amp;theme=light" alt="LinearMemory - Agentic Knowledge Explorer | Product Hunt" width="250" height="54" /></a>
     <a href="https://trendshift.io/repositories/213782?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-213782" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Track_on-Trendshift-2563EB?style=for-the-badge" alt="Track LinearMemory on Trendshift" height="28" /></a>
   </p>
 </div>


### PR DESCRIPTION
## Summary

- merge back the latest Snyk Docker security update into \develop\`n- remove the Product Hunt banner from the README
- keep the Trendshift and technical badges