### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/apps/mcp/src/backup.ts
+++ b/apps/mcp/src/backup.ts
@@ -33,6 +33,10 @@ function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
+function isSafeSqlIdentifier(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
 async function exportTable(client: PoolClient, table: TableName): Promise<TableBackup> {
   const columns = await client.query<{ column_name: string }>(
     `SELECT column_name
@@ -95,6 +99,9 @@ async function importTable(client: PoolClient, table: TableName, data: TableBack
   const allowed = new Set(currentColumns.rows.map(row => row.column_name));
   const dataTypes = new Map(currentColumns.rows.map(row => [row.column_name, row.data_type]));
   if (data.columns.some(column => !allowed.has(column))) throw new Error(`Backup table ${table} contains unknown columns.`);
+  if (data.columns.some(column => !isSafeSqlIdentifier(column))) {
+    throw new Error(`Backup table ${table} contains invalid column identifiers.`);
+  }
   const columns = data.columns.map(quoteIdentifier).join(',');
   const placeholders = data.columns.map((_, index) => `$${index + 1}`).join(',');
   const identityOverride = table === 'memory_events' ? ' OVERRIDING SYSTEM VALUE' : '';


### PR DESCRIPTION
Potential fix for [https://github.com/jucelioalencar/linearmemory/security/code-scanning/1](https://github.com/jucelioalencar/linearmemory/security/code-scanning/1)

To fix this without changing functionality, add strict identifier validation for backup column names before building SQL identifiers. Keep parameterized values as-is, but ensure every column name is a plain SQL identifier (e.g., `^[A-Za-z_][A-Za-z0-9_]*$`) in addition to being in the allowed schema list. This guarantees user input cannot inject SQL syntax through identifier positions and provides a strong, explicit guard that static analysis can recognize better.

In `apps/mcp/src/backup.ts`:
- Add a small helper function (near `quoteIdentifier`) to validate identifier format.
- In `importTable`, after unknown-column check and before `columns = data.columns.map(quoteIdentifier)...`, reject invalid identifier format.
- Keep existing logic (`allowed` set, parameterized values, `quoteIdentifier`) unchanged otherwise.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
