### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/apps/mcp/src/backup.ts
+++ b/apps/mcp/src/backup.ts
@@ -102,12 +102,16 @@ async function importTable(client: PoolClient, table: TableName, data: TableBack
   if (data.columns.some(column => !isSafeSqlIdentifier(column))) {
     throw new Error(`Backup table ${table} contains invalid column identifiers.`);
   }
-  const columns = data.columns.map(quoteIdentifier).join(',');
-  const placeholders = data.columns.map((_, index) => `$${index + 1}`).join(',');
+  const trustedColumns = currentColumns.rows
+    .map(row => row.column_name)
+    .filter(column => data.columns.includes(column));
+  if (!trustedColumns.length) return;
+  const columns = trustedColumns.map(quoteIdentifier).join(',');
+  const placeholders = trustedColumns.map((_, index) => `$${index + 1}`).join(',');
   const identityOverride = table === 'memory_events' ? ' OVERRIDING SYSTEM VALUE' : '';
   const sql = `INSERT INTO memory.${quoteIdentifier(table)} (${columns})${identityOverride} VALUES (${placeholders})`;
   for (const [rowIndex, row] of data.rows.entries()) {
-    const values = data.columns.map(column => serializeImportValue(row[column], dataTypes.get(column)));
+    const values = trustedColumns.map(column => serializeImportValue(row[column], dataTypes.get(column)));
     try {
       await client.query(sql, values);
     } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/jucelioalencar/linearmemory/security/code-scanning/1](https://github.com/jucelioalencar/linearmemory/security/code-scanning/1)

General fix: avoid constructing SQL identifiers from request-derived data. For restore logic, derive insert columns from trusted schema metadata and fixed table order, then map incoming row values into that trusted column list.

Best fix in this file: in `importTable`, keep validating incoming `data.columns`, but **do not** use `data.columns` to build `columns`, `placeholders`, or `values` mapping. Instead:
1. Build a trusted ordered column list from `currentColumns.rows` (schema introspection), excluding generated columns already filtered in query.
2. For each row, use only trusted columns that are present in the backup payload (intersection), preserving trusted order.
3. Build SQL from those trusted columns and run parameterized values as today.

This preserves functionality (restore only known columns from backup) while removing tainted identifier influence over SQL text. Edits are only in `apps/mcp/src/backup.ts`, inside `importTable`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
