### PR TITLE
fix: remove Alpine CVEs from MCP image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
+          pull: true
           push: true
           tags: |
             ${{ needs.prepare.outputs.registry }}/linearmemory-${{ matrix.image }}:latest

--- a/apps/mcp/Dockerfile
+++ b/apps/mcp/Dockerfile
@@ -10,7 +10,8 @@ RUN npm run build
 FROM node:24.19.0-alpine3.24
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev \
+RUN apk upgrade --no-cache \
+    && npm ci --omit=dev \
     && npm cache clean --force \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
## Summary

- upgrades Alpine runtime packages before installing MCP production dependencies
- updates OpenSSL runtime libraries from 3.5.7-r0 to the patched 3.5.8-r0 release
- forces release builds to pull the newest base-image layers
- preserves the reduced runtime image without the global npm installation

## Validation

- rebuilt the MCP image from scratch with --pull and --no-cache
- confirmed libcrypto3 and libssl3 were upgraded to 3.5.8-r0
- confirmed no outdated Alpine packages remained
- confirmed Node.js and the npm-free production runtime remain functional
- validated the release workflow YAML